### PR TITLE
Fix plugin signing to skip when credentials unavailable

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -151,6 +151,11 @@ tasks {
         certificateChain.set(System.getenv("CERTIFICATE_CHAIN"))
         privateKey.set(System.getenv("PRIVATE_KEY"))
         password.set(System.getenv("PRIVATE_KEY_PASSWORD"))
+        
+        // Skip signing if credentials are not available
+        enabled = !System.getenv("CERTIFICATE_CHAIN").isNullOrEmpty() && 
+                  !System.getenv("PRIVATE_KEY").isNullOrEmpty() && 
+                  !System.getenv("PRIVATE_KEY_PASSWORD").isNullOrEmpty()
     }
 
     publishPlugin {


### PR DESCRIPTION
- Make signPlugin task conditional based on environment variables
- Prevents CI/CD failures when signing secrets are not available (e.g., PR builds)
- Maintains security by only requiring credentials for actual releases

🤖 Generated with [Claude Code](https://claude.ai/code)